### PR TITLE
mine_sweeper.py -> init_mine() minecount difference pathed

### DIFF
--- a/MineSweeper.py
+++ b/MineSweeper.py
@@ -63,15 +63,12 @@ def init_mine():
                 return 1
         return 0
         
-    for mine in range(setting['minecount']):
+    while mines != setting['minecount']:
         row=random.randint(1,setting['mapsize']['row'])
         col=random.randint(1,setting['mapsize']['col'])
         errors=checksum(row,col)
         if not errors==0:
-            while errors!=0:
-                row=random.randint(1,setting['mapsize']['row'])
-                col=random.randint(1,setting['mapsize']['col'])
-                errors=checksum(row,col)
+            continue
         else:
             mines.append({row:col})
 


### PR DESCRIPTION
fixed mines less than settings; used `while` instead of `for` in `init_mine()` and deleted useless _forcefully appending mine_ and instead passed its responsibility to while constrain